### PR TITLE
fix: required packages in prerequisites.ps1

### DIFF
--- a/envs/windows/prerequisites.ps1
+++ b/envs/windows/prerequisites.ps1
@@ -12,7 +12,7 @@ if ($null -eq (Get-Command scoop.ps1*)) {
 }
 
 PrintInfo -message "install/update required scoop package"
-foreach ($item in @("git", "innounp", "dark", "sudo", "dark")) {
+foreach ($item in @("7zip", "dark", "git", "innounp", "sudo")) {
   scoop install $item
   scoop update $item
   if (!$?) {


### PR DESCRIPTION
In order to run Scoop-Playbook, need the 7-zip.

![](https://user-images.githubusercontent.com/16175660/90070624-24462680-dd2f-11ea-8ee3-3094a8d7f4d7.png)

The following corrections have been made

- Add 7-zip to the required package.
- Removed the duplicate darks.
- Change to alphabetical order like the others.