### PR TITLE
fix: ansible-lint error

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,5 +7,6 @@ skip_list:
   - schema[vars] # macos detect wrong error on defaults
   - var-naming[non-string] # for macOS only.
   - var-naming[no-role-prefix] # too much. It's nothing worse to follow this rule.
+  - yaml[comment] # too noisy. I don't want to comment new line every time. inline comment is useful.
   - yaml[indentation]
   - yaml[line-length] # don't think line-length is important

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -6,11 +6,15 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/ansible-lint.yaml
+      - .ansible-lint.yaml
       - "envs/**/*.yaml"
   pull_request:
     branches:
       - main
     paths:
+      - .github/workflows/ansible-lint.yaml
+      - .ansible-lint.yaml
       - "envs/**/*.yaml"
 
 env:

--- a/envs/include_role/ubuntu/install_dotnet.yaml
+++ b/envs/include_role/ubuntu/install_dotnet.yaml
@@ -9,3 +9,4 @@
 
 - name: "dotnet - install ({{ dotnet.version }})"
   ansible.builtin.shell: "DOTNET_ROOT={{ ansible_home }}/.dotnet && /tmp/dotnet-install.sh --channel {{ dotnet.version }}"
+  changed_when: false


### PR DESCRIPTION
fix: https://github.com/guitarrapc/local-provisioner/actions/runs/6312515096/job/17138722898

```
WARNING  Listing 1 violation(s) that are fatal
yaml[comments]: Missing starting space in comment
envs/ubuntu/roles/tools/vars/main.yml:[7](https://github.com/guitarrapc/local-provisioner/actions/runs/6312515096/job/17138722898#step:5:8)

Error: Missing starting space in comment
Read ]8;id=515984;https://ansible-lint.readthedocs.io/configuring/#ignoring-rules-for-entire-files\documentation]8;;\ for instructions on how to ignore specific rule violations.

              Rule Violation Summary               
 count tag            profile rule associated tags 
     1 yaml[comments] basic   formatting, yaml     

Failed: 1 failure(s), 0 warning(s) on 30 files. Last profile that met the validation criteria was 'min'.
Error: Process completed with exit code 2.
```