### PR TITLE
feat: kubectx/kubens as git tool for bash completion

### DIFF
--- a/envs/ubuntu/roles/tools/vars/main.yml
+++ b/envs/ubuntu/roles/tools/vars/main.yml
@@ -73,6 +73,11 @@ dpkg:
 git_tools:
   - name: kube-ps1
     git_https_url: https://github.com/jonmosco/kube-ps1.git
+  - name: kubectx
+    git_https_url: https://github.com/ahmetb/kubectx.git
+    link_binaries:
+      - kubectx
+      - kubens
 
 go:
   version: "go" # install latest


### PR DESCRIPTION
## tl;dr;

kubectx and kubens bash completion is supported by bash completion which need git clone. It means installing kubectx/kubens binary via aqua won't be able to enable bash completion.

Let's revert back kubectx/kubens from aqua to git tool.