### PR TITLE
feat: change pip3 to pipx for Ubuntu 24.04

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -18,8 +18,12 @@ env:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -42,8 +46,12 @@ jobs:
         run: ansible-playbook -i hosts playbook.yaml --check --diff
 
   macos:
-    runs-on: macos-latest
-    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-15, macos-14]
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -67,7 +75,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     defaults:
       run:
         shell: powershell

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Dev environment setup.
 
 | Environment | Version | Method | Note |
 | ---- | ---- | ---- | ---- |
-| [macOS](envs/macos/README.md) | Ventura<br/>Monterey | Ansible Playbook | Target to Apple Silicon and Intel. |
-| [Ubuntu](envs/ubuntu/README.md) | 22.04<br/>20.04<br/>WSL1<br/>WSL2 | Ansible Playbook | install docker on wsl2. |
+| [macOS](envs/macos/README.md) | Sequoia(15.0)<br/>Sonoma(14.0) | Ansible Playbook | Target to Apple Silicon and Intel. |
+| [Ubuntu](envs/ubuntu/README.md) | 24.04 (WSL1/WSL2)<br/>22.04 (WSL1/WSL2) | Ansible Playbook | install docker on wsl2. |
 | [Windows](envs/windows/README.md) | 11<br/>10 | scoop & winget | scoop for portal app, winget for installer app. |
 
 # Run
@@ -124,6 +124,8 @@ Out of scopes
 
 **Windows**
 
+Scope for following.
+
 Role | Descriptions
 ---- | ----
 ba230t | install app via scoop's `ba230t` bucket
@@ -132,12 +134,13 @@ guitarrapc | install app via scoop's `guitarrapc` bucket
 main | install app via scoop's `main` bucket
 terraform-docs | install app via scoop's `terraform-docs` bucket
 
-Use winget to install non-scoop apps.
+winget for following
 
-* Docker for Windows.
-* Visual Studio or higher.
+* Docker for Windows
+* Visual Studio or higher
 * Unity Hub
-* Steam and others.
+* Steam
+* other apps
 
 # How to modify
 
@@ -145,17 +148,18 @@ Folk this repository.
 
 **macOS**
 
-    * Modify parameters: `envs/macos/roles/<role>/vars/main.yml`.
-    * Modify logics: `envs/macos/roles/<role>/tasks/main.yml`.
+* Modify parameters: `envs/macos/roles/<role>/vars/main.yml`.
+* Modify logics: `envs/macos/roles/<role>/tasks/main.yml`.
 
 **Ubuntu**
 
-    * Modify parameters: `envs/ubuntu/roles/<role>/vars/main.yml`.
-    * Modify logics: `envs/ubuntu/roles/<role>/tasks/main.yml`.
+* Modify parameters: `envs/ubuntu/roles/<role>/vars/main.yml`.
+* Modify logics: `envs/ubuntu/roles/<role>/tasks/main.yml`.
+* Modify reuse logics: `envs/include_roleroles/ubuntu/<role>.yml`.
 
 **Windows**
 
-    * Modify logics: `envs/windows/roles/<role>/tasks/main.yml`.
+* Modify logics: `envs/windows/roles/<role>/tasks/main.yml`.
 
 # Issues
 

--- a/envs/ubuntu/prerequisites.sh
+++ b/envs/ubuntu/prerequisites.sh
@@ -2,29 +2,39 @@
 set -eu -o pipefail
 
 required_python3_version="3.13"
-required_ansible_version="2.17.3"
 
-# update apt
-sudo apt update -y
-sudo apt autoremove -y
+function update_apt {
+  sudo apt update -y
+  sudo apt autoremove -y
+}
+
+function print_title {
+  echo ""
+  echo "#############################################"
+  echo "# $1"
+  echo "#############################################"
+}
 
 function hack:wsl1_ubuntu20 {
-    if lshw | grep vsyscall32; then
-      is_wsl2=1
+  # target = Ubuntu20.04LTS on WSL1
+  if lshw | grep vsyscall32 > /dev/null 2>&1; then
+    is_wsl2=1
+  fi
+  if lsb_release -r | grep -c "20.04" > /dev/null 2>&1; then
+    is_ubuntu2004=1
+  fi
+  if [[ "${is_wsl2:-0}" == "0" && "${is_ubuntu2004:-0}" == "1" ]]; then
+    # sleep cannot use in WSL1 Ansible hack
+    echo "detected Ubuntu 20.04 on WSL1, applying sleep hack. https://stackoverflow.com/questions/62363901/ansible-msg-failed-to-create-temporary-directory-in-some-cases-fatal"
+    if [[ ! -L "/bin/sleep" ]]; then
+      sudo mv /bin/sleep /bin/sleep~
+      sudo ln -s /bin/busybox /bin/sleep
     else
-      is_wsl2=0
+      echo "sleep symlink already exists."
     fi
-    is_ubuntu2004=$(lsb_release -r | grep -c "20.04")
-    if [[ "${is_wsl2}" == "0" && "${is_ubuntu2004}" == "1" ]]; then
-      # sleep cannot use in WSL1 Ansible hack
-      echo "detected Ubuntu 20.04 on WSL1, applying sleep hack. https://stackoverflow.com/questions/62363901/ansible-msg-failed-to-create-temporary-directory-in-some-cases-fatal"
-      if [[ ! -L "/bin/sleep" ]]; then
-        sudo mv /bin/sleep /bin/sleep~
-        sudo ln -s /bin/busybox /bin/sleep
-      else
-        echo "sleep symlink already exists."
-      fi
-    fi
+  else
+    echo "No need to apply sleep hack."
+  fi
 }
 
 function install_python3 {
@@ -32,38 +42,37 @@ function install_python3 {
   sudo apt install -y software-properties-common
   sudo add-apt-repository -y ppa:deadsnakes/ppa
   sudo apt update -y
-  sudo apt -y install "python${required_python3_version}" "python3-pip"
+  sudo apt -y install "python${required_python3_version}" "python3-pip" "pipx"
+  pipx ensurepath
 }
 
 function install_ansible {
   # Install Ansible from ppa for latest release and fast update.
-  # `pip3 install --user ansible` is too slow and could not accept.
+  # `pipx install --user ansible` is too slow and could not accept.
   echo "Install ansible from ppa."
   if ! ls /etc/apt/sources.list.d/ansible-*-ansible*.list > /dev/null 2>&1; then
     sudo add-apt-repository -y --update ppa:ansible/ansible
   fi
   sudo apt update -y
   sudo apt install -y ansible
-
-  # install ansible-lint
-  pip3 install --user ansible-lint
 }
 
-echo "# Checking pip3 installed."
-if ! command -v "python${required_python3_version}" > /dev/null 2>&1; then
-  echo "python${required_python3_version} not found, install it."
-  install_python3
-else
-  echo "python${required_python3_version} found."
-fi
+function show_tool_versions {
+  python3 --version
+  ansible --version
+}
 
-echo "# Checking ansible installed."
-if ! command -v ansible > /dev/null 2>&1 || ! ansible --version | grep "${required_ansible_version}" > /dev/null 2>&1; then
-  echo "Ansible not found, install it."
-  install_ansible
+print_title "Updating apt."
+update_apt
 
-  # target = Ubuntu20.04LTS on WSL1
-  hack:wsl1_ubuntu20
-else
-  echo "Ansible ${required_ansible_version} found."
-fi
+print_title "Installing python and tools."
+install_python3
+
+print_title "Installing Ansible."
+install_ansible
+
+print_title "Checking and hack for WSL1 Ubuntu 20.04"
+hack:wsl1_ubuntu20
+
+print_title "Show tool versions."
+show_tool_versions

--- a/envs/ubuntu/roles/tools/tasks/main.yml
+++ b/envs/ubuntu/roles/tools/tasks/main.yml
@@ -8,10 +8,9 @@
   retries: 2 # wsl1 failed first apt on Ubuntu-22.04
   when: feature_enabed.apts == "true"
 
-- name: "pip3 - Install pip3 packages"
-  ansible.builtin.pip:
-    name: "{{ item.name }}"
-    version: "{{ item.version }}"
+- name: "pip3 - Install pip3 packages with pipx"
+  community.general.pipx:
+    name: "{{ item.name }}=={{ item.version }}"
   with_items: "{{ pip3 }}"
   when: feature_enabed.pip3 == "true"
 

--- a/envs/ubuntu/roles/tools/vars/main.yml
+++ b/envs/ubuntu/roles/tools/vars/main.yml
@@ -113,6 +113,6 @@ krew_plugins:
 
 pip3:
   - name: ansible-lint # https://github.com/ansible/ansible-lint
-    version: "24.7.0"
+    version: "24.9.2"
   - name: ansible-playbook-grapher # require: graphviz https://github.com/haidaraM/ansible-playbook-grapher
-    version: "2.2.1"
+    version: "2.3.0"

--- a/envs/windows/etc/install-wsl2.ps1
+++ b/envs/windows/etc/install-wsl2.ps1
@@ -1,5 +1,5 @@
 wsl --set-default-version 2
-wsl --install -d Ubuntu-22.04
+wsl --install -d Ubuntu-24.04
 
 sleep 5s
-wsl --set-default Ubuntu-22.04
+wsl --set-default Ubuntu-24.04


### PR DESCRIPTION
## tl;dr;

python on Ubuntu 24.04 default not allow to install system-wide tools by pip3. Change tool installation from pip3 to pipx instead.